### PR TITLE
Include c for compute in fqdn

### DIFF
--- a/lib/adapter/instance_groups.ex
+++ b/lib/adapter/instance_groups.ex
@@ -54,7 +54,7 @@ defmodule Cluster.Strategy.Adapter.InstanceGroups do
             %{"instance_name" => instance_name} =
               Regex.named_captures(~r/.*\/(?<instance_name>.*)$/, instance)
 
-            :"#{release_name}@#{instance_name}.#{zone}.#{project}.internal"
+            :"#{release_name}@#{instance_name}.#{zone}.c.#{project}.internal"
           end)
 
         {:ok, nodes}


### PR DESCRIPTION
Based on this article 

https://stackoverflow.com/questions/53535094/what-does-the-c-stand-for-in-a-google-cloud-platform-internal-dns-fqdn

And this one 

https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names